### PR TITLE
Add CHANGELOG bot

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,0 +1,23 @@
+name: Changelog Bot
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - CHANGELOG.md
+
+jobs:
+  changelog-bot:
+    runs-on: ubuntu-latest
+    name: Update CHANGELOG.md
+    steps:
+      - name: Update Changelog
+        uses: docker://ponylang/changelog-bot-action:0.3.4
+        with:
+          git_user_name: "Borja o'Cook"
+          git_user_email: "ergl@users.noreply.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,15 @@
+name: PR
+
+on: pull_request
+
+jobs:
+  verify-changelog:
+    name: Verify CHANGELOG is valid
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/changelog-tool:release
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Verify CHANGELOG
+        run: changelog-tool verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+
+## [unreleased] - unreleased
+
+### Fixed
+
+
+### Added
+
+
+### Changed
+
+
+## [0.1.0] - 2021-06-07
+
+### Added
+
+- Initial version


### PR DESCRIPTION
Adds the standard ponylang changelog management bot as well as the required
CHANGELOG.md. Additionally, it adds a check for pull requests that they
haven't made an invalid change to the CHANGELOG.