### PR TITLE
Setup standard pony project release notes handling

### DIFF
--- a/.github/workflows/release-notes-bot.yml
+++ b/.github/workflows/release-notes-bot.yml
@@ -1,0 +1,24 @@
+name: Release Notes Bot
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - .release-notes/next-release.md
+      - .release-notes/\d+.\d+.\d+.md
+
+jobs:
+  release-notes-bot:
+    runs-on: ubuntu-latest
+    name: Update release notes
+    steps:
+      - name: Update
+        uses: docker://ponylang/release-notes-bot-action:0.3.4
+        with:
+          git_user_name: "Borja o'Cook"
+          git_user_email: "ergl@users.noreply.github.com"
+        env:
+          API_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-notes-reminder-bot.yml
+++ b/.github/workflows/release-notes-reminder-bot.yml
@@ -1,0 +1,15 @@
+name: Release Notes Reminder Bot
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  release-note-reminder-bot:
+    runs-on: ubuntu-latest
+    name: Prompt to add release notes
+    steps:
+      - name: Prompt to add release notes
+        uses: docker://ponylang/release-notes-reminder-bot-action:0.1.0
+        env:
+          API_CREDENTIALS: ${{ secrets.API_TOKEN }}


### PR DESCRIPTION
This adds everything related to building up release notes that isn't
the rotation of release notes after a release (that's handled by the
release-bot-action which will be installed later).

For this to work, a new secret needs to be added to this repository
under the name API_TOKEN. API_TOKEN should be a GitHub API token that
allows public repo access. You should add the token under your ergl
account.

Note, the release-notes-bot will skip adding release notes for any PR
that doesn't have one of the changelog - * labels.