### PR TITLE
Add tests that check that code works with the latest ponyc

### DIFF
--- a/.github/workflows/breakages-against-ponyc-latest.yml
+++ b/.github/workflows/breakages-against-ponyc-latest.yml
@@ -1,0 +1,28 @@
+name: Nightly Breakage Test
+
+on:
+  repository_dispatch:
+    types: [shared-docker-linux-builders-updated]
+
+jobs:
+  linux-release-vs-ponyc-main:
+    name: Verify in release mode on Linux with most recent ponyc
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Test with the most recent ponyc
+        run: make test config=release
+
+  linux-debug-vs-ponyc-main:
+    name: Verify in debug mode on Linux with most recent ponyc
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Test with the most recent ponyc
+        run: make test config=debug


### PR DESCRIPTION
This adds a test that runs every evening against the most recent
ponyc build to make sure that everything still works with the latest
ponyc changes.

This particular configuration uses GitHub notifications to trigger
the run. For this to work, you'll need to invite the user ponylang-main
to be a collaborator on the project and that account will have to accept.

Additionally, a PR to send a message to this repo when the nightly builders
are updated will need to be added to the `ponylang/shared-docker` repo.

This workflow could also be run on a schedule but that, while less work
to set up, is also less precise.