### PR TITLE
Add the ability to manually generate docs and post to GH pages

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,0 +1,22 @@
+name: Manually generate documentation
+
+on:
+  workflow_dispatch
+
+jobs:
+  generate-documentation:
+    name: Generate documentation for release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Generate documentation and upload
+        uses: docker://ponylang/library-documentation-action:0.1.6
+        with:
+          site_url: "https://ergl.github.io/pony-protobuf/"
+          library_name: "protobuf"
+          docs_build_dir: "build/protobuf-docs"
+          git_user_name: "Borja o'Cook"
+          git_user_email: "ergl@users.noreply.github.com"
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ primitive PhoneType
 
 This option is shorter, doesn't pollute the namespace, but doesn't offer any type-checking affordances to the user. That's the reason I opted for the more verbose alternative. In the future, I might change this.
 
+## API Documentation
+
+[API documentation](https://ergl.github.io/pony-protobuf/)
+
 ## Performance
 
 Baby steps.

--- a/corral.json
+++ b/corral.json
@@ -16,7 +16,7 @@
     "description": "A protocol buffers library for Pony",
     "homepage": "https://github.com/ergl/pony-protobuf",
     "license": "BSD-2-Clause",
-    "documentation_url": "",
+    "documentation_url": "https://ergl.github.io/pony-protobuf/",
     "version": "0.10",
     "name": "protobuf"
   }


### PR DESCRIPTION
For this PR to work the instructions for setup for GH pages need to
followed the first time after this is manually triggered.

Additionally, before triggering, a repository secret called RELEASE_TOKEN
needs to be set up. Access required for that token can be found in
the instructions at:

https://github.com/ponylang/library-documentation-action