### PR TITLE
Remove FieldSize.packed_enum_size

### DIFF
--- a/.release-notes/13.md
+++ b/.release-notes/13.md
@@ -1,0 +1,3 @@
+## Remove FieldSize.packed_enum_size
+
+This is a redundant function, since `FieldSize.packed_enum[T]` already exists.

--- a/protobuf/field_tags.pony
+++ b/protobuf/field_tags.pony
@@ -160,17 +160,6 @@ primitive FieldSize
       _tag_size(field) + raw_varint(data_size.u64()) + data_size
     end
 
-  fun packed_enum_size(field: U64, arg: Array[ProtoEnumValue] box): U32 =>
-    if arg.size() == 0 then
-      0
-    else
-      var data_size: U32 = 0
-      for v in arg.values() do
-        data_size = data_size + raw_varint(v.as_i32().u64())
-      end
-      _tag_size(field) + raw_varint(data_size.u64()) + data_size
-    end
-
   fun _tag_size(field: U64): U32 => raw_varint((field << 3))
 
   // From


### PR DESCRIPTION
It's redundant, `packed_enum[T]` should be used