### PR TITLE
Improve front-end error reporting

### DIFF
--- a/.release-notes/17.md
+++ b/.release-notes/17.md
@@ -1,0 +1,4 @@
+## Improve front-end error reporting
+
+The compiler should now give better error messages.
+

--- a/protobuf/_plugin/codegen_check_pass.pony
+++ b/protobuf/_plugin/codegen_check_pass.pony
@@ -1,0 +1,356 @@
+use ".."
+
+type CheckResult[T] is Result[T, String]
+type CheckResults[T] is Results[T, String]
+
+type _ValidEnums is Array[ValidEnumDescriptorProto] val
+type _ValidMessages is Array[ValidDescriptorProto] val
+type _Step0 is String
+type _Step1 is (String, String)
+type _Step2 is (String, String, _ValidEnums)
+type _Step3 is (String, String, _ValidEnums, _ValidMessages)
+
+primitive CodeGenCheckPass
+  fun _check_name(
+    descr: FileDescriptorProto box)
+    : CheckResult[String]
+  =>
+    match descr.name
+    | None => (Error, "Supplied descriptor doesn't have a name")
+    | let name: String => (Ok, GenNames.proto_file(name))
+    end
+
+  fun _check_proto_version(
+    name: String, descr: FileDescriptorProto box)
+    : CheckResult[String]
+  =>
+    match descr.syntax
+    | "proto3" => (Error, "pony-protobuf only supports proto2 files")
+    else
+      (Ok, name)
+    end
+
+  fun _build_package(
+    name: String, descr: FileDescriptorProto box)
+    : (String, String)
+  =>
+    let package = try descr.package as String else "" end
+    (name, package)
+
+  fun _check_enums(
+    proto_enums: Array[EnumDescriptorProto] box)
+    : CheckResult[_ValidEnums]
+  =>
+    let enums = recover Array[ValidEnumDescriptorProto] end
+    for enum in proto_enums.values() do
+      try
+        let fields = recover Array[(String, I32)] end
+        let enum_name = enum.name as String
+        for field in enum.value.values() do
+          let field_name = field.name as String
+          let field_number = field.number as I32
+          fields.push((field_name, field_number))
+        end
+        enums.push(
+          ValidEnumDescriptorProto(
+            enum_name,
+            consume fields
+          )
+        )
+      else
+        return (Error, "pony-protobuf found invalid enum")
+      end
+    end
+    (Ok, consume enums)
+
+  fun _check_oneofs(
+    oneof_decls: Array[OneofDescriptorProto] box)
+    : Array[String] val
+    ?
+  =>
+    let decls = recover Array[String] end
+    for decl in oneof_decls.values() do
+      decls.push(decl.name as String)
+    end
+    consume decls
+
+  fun _check_field_type(
+    message_name: String,
+    field_name: String,
+    type_field: (FieldDescriptorProtoType | None),
+    type_name: (String | None))
+    : CheckResult[(AllowedProtoTypes |
+                  (MessageType, String) |
+                  (EnumType, String))]
+  =>
+    
+    match type_name
+    | let value: String => 
+      match type_field
+      | None =>
+        // If type_field is not set, assume this is a message
+        (Ok, (MessageType, consume value))
+      | FieldDescriptorProtoTypeTYPEENUM =>
+        (Ok, (EnumType, consume value))
+      | FieldDescriptorProtoTypeTYPEMESSAGE =>
+        (Ok, (MessageType, consume value))
+      | FieldDescriptorProtoTypeTYPEGROUP =>
+        (
+          Error,
+          "pony-protobuf: " +
+          message_name + "." + field_name +
+          ": group fields are not allowed"
+        )
+      else
+        (
+          Error,
+          "pony-protobuf: invalid field type for "
+          message_name + "." + field_name +
+          ": only enums and messages are allowed"
+        )
+      end
+    | None =>
+      match type_field
+      | FieldDescriptorProtoTypeTYPEGROUP =>
+        (
+          Error,
+          "pony-protobuf: " +
+          message_name + "." + field_name +
+          ": group fields are not allowed"
+        )
+      | FieldDescriptorProtoTypeTYPEBOOL => (Ok, BoolFieldType)
+      | FieldDescriptorProtoTypeTYPEINT32 => (Ok, I32FieldType)
+      | FieldDescriptorProtoTypeTYPEUINT32 => (Ok, U32FieldType)
+      | FieldDescriptorProtoTypeTYPEINT64 => (Ok, I64FieldType)
+      | FieldDescriptorProtoTypeTYPEUINT64 => (Ok, U64FieldType)
+
+      | FieldDescriptorProtoTypeTYPESINT32 => (Ok, I32ZigZagFieldType)
+      | FieldDescriptorProtoTypeTYPESINT64 => (Ok, I64ZigZagFieldType)
+
+      | FieldDescriptorProtoTypeTYPEDOUBLE => (Ok, F64FieldType)
+      | FieldDescriptorProtoTypeTYPEFLOAT => (Ok, F32FieldType)
+      | FieldDescriptorProtoTypeTYPESFIXED32 => (Ok, FixedI32FieldType)
+      | FieldDescriptorProtoTypeTYPESFIXED64 => (Ok, FixedI64FieldType)
+      | FieldDescriptorProtoTypeTYPEFIXED32 => (Ok, FixedU32FieldType)
+      | FieldDescriptorProtoTypeTYPEFIXED64 => (Ok, FixedU64FieldType)
+
+      | FieldDescriptorProtoTypeTYPESTRING => (Ok, StringFieldType)
+      | FieldDescriptorProtoTypeTYPEBYTES => (Ok, BytesFieldType)
+      | FieldDescriptorProtoTypeTYPEENUM =>
+        (
+          Error,
+          "pony-protobuf: field " + message_name + "." + field_name +
+            " is enum, but no type name was provided"
+        )
+      | FieldDescriptorProtoTypeTYPEMESSAGE =>
+        (
+          Error, 
+          "pony-protobuf: field " + message_name + "." + field_name +
+            " is nested message, but no type name was provided"
+        )
+      else
+        (
+          Error,
+          "pony-protobuf: invalid precondition on " +
+          message_name + "." + field_name +
+          ": neither type_name or type are set"
+        )
+      end
+    end
+
+  fun _check_fields(
+    message_name: String,
+    fields: Array[FieldDescriptorProto] box)
+    : CheckResult[Array[ValidFieldDescriptorProto] val]
+  =>
+    let valid_fields = recover Array[ValidFieldDescriptorProto] end
+    for field in fields.values() do
+      try
+        let name = GenNames.message_field(field.name as String)
+        let number = field.number as I32
+        let label = field.label as FieldDescriptorProtoLabel
+        let is_packed =
+          try
+            (field.options as FieldOptions box).packed as Bool
+          else
+            false
+          end
+
+        let type_result = _check_field_type(
+          message_name,
+          name,
+          field.type_field,
+          field.type_name
+        )
+
+        match type_result
+        | (Error, let msg: String) =>
+          return (Error, msg)
+        | (Ok, let field_type: AllowedProtoTypes) =>
+          valid_fields.push(
+            ValidFieldDescriptorProto(
+              name,
+              number,
+              label,
+              field_type,
+              None,
+              field.default_value,
+              field.oneof_index,
+              is_packed
+            )
+          )
+        | (Ok, (MessageType, let msg_name: String)) =>
+          valid_fields.push(
+            ValidFieldDescriptorProto(
+              name,
+              number,
+              label,
+              None,
+              (MessageType, msg_name),
+              field.default_value,
+              field.oneof_index,
+              is_packed
+            )
+          )
+        | (Ok, (EnumType, let msg_name: String)) =>
+          valid_fields.push(
+            ValidFieldDescriptorProto(
+              name,
+              number,
+              label,
+              None,
+              (EnumType, msg_name),
+              field.default_value,
+              field.oneof_index,
+              is_packed
+            )
+          )
+        end
+      else
+        return (Error, "pony-protobuf found invalid field")
+      end
+    end
+    (Ok, consume valid_fields)
+
+  fun _check_messages(
+    descr_name: String,
+    wanted_file: String,
+    proto_messages: Array[DescriptorProto] box,
+    recursion_level: USize = 0)
+    : CheckResult[_ValidMessages]
+  =>
+
+    let limit = CodeGen.recursion_limit()
+    if recursion_level > limit then
+      return (Error, "Reached message recursion limit: " + limit.string())
+    end
+
+    // We don't need to check the entire descriptor if this is
+    // a dependency. For example, there's no need to go through
+    // the fields, or the oneof declarations.
+    let is_dependency = wanted_file != descr_name
+    let messages = recover Array[ValidDescriptorProto] end
+    for message in proto_messages.values() do
+      try
+        let name = message.name as String
+
+        let oneof_decls =
+          if is_dependency then
+            recover val Array[String] end
+          else
+            _check_oneofs(message.oneof_decl)?
+          end
+
+        // Don't care about the internal reasons
+        let nested_enums =
+          CheckResults[_ValidEnums].force_ok(
+            _check_enums(message.enum_type)
+          )?
+
+        // We want to keep the recursion error
+        let nested_messages_result = _check_messages(descr_name, wanted_file,
+          message.nested_type, recursion_level + 1)
+
+        match nested_messages_result
+        | (Error, let reason: String) =>
+          return (Error, reason)
+        | (Ok, let nested_messages: Array[ValidDescriptorProto] val) =>
+          let fields_result =
+            if is_dependency then
+              (Ok, recover val Array[ValidFieldDescriptorProto] end)
+            else
+              _check_fields(name, message.field)
+            end
+            match fields_result
+            | (Error, let reason: String) =>
+              return (Error, reason)
+            | (Ok, let fields: Array[ValidFieldDescriptorProto] val) =>
+              messages.push(
+                ValidDescriptorProto(
+                  name,
+                  fields,
+                  nested_enums,
+                  nested_messages,
+                  oneof_decls
+                )
+              )
+            end
+        end
+      else
+        return (Error, "pony-protobuf found invalid message")
+      end
+    end
+    (Ok, consume messages)
+
+  fun apply(
+    wanted_file: String,
+    descriptor: FileDescriptorProto box)
+    : CheckResult[ValidFileDescriptorProto]
+  =>
+
+    let name_result = _check_name(descriptor)
+
+    let version_result = CheckResults[String].flat_lmap[_Step0](
+      name_result,
+      {(name)(descriptor) =>
+        CodeGenCheckPass._check_proto_version(name, descriptor)}
+    )
+
+    let package_result = CheckResults[_Step0].lmap[_Step1](
+      version_result,
+      {(name)(descriptor) =>
+        CodeGenCheckPass._build_package(name, descriptor)}
+    )
+
+    let enums_result = CheckResults[_Step1].flat_lmap[_Step2](
+      package_result,
+      {(prev)(descriptor) =>
+        CheckResults[_ValidEnums].lmap[_Step2](
+          CodeGenCheckPass._check_enums(descriptor.enum_type),
+          {(enums) => (prev._1, prev._2, enums)}
+        )
+      }
+    )
+
+    let messages_result = CheckResults[_Step2].flat_lmap[_Step3](
+      enums_result,
+      {(prev)(wanted_file, descriptor) =>
+        CheckResults[_ValidMessages].lmap[_Step3](
+          CodeGenCheckPass._check_messages(prev._1, wanted_file,
+            descriptor.message_type),
+          {(messages) => (prev._1, prev._2, prev._3, messages)}
+        )
+      }
+    )
+
+    CheckResults[_Step3].lmap[ValidFileDescriptorProto](
+      messages_result,
+      {(all_fields) =>
+        ValidFileDescriptorProto(
+          all_fields._1,
+          all_fields._2,
+          all_fields._3,
+          all_fields._4
+        )
+      }
+    )

--- a/protobuf/_plugin/codegen_enums.pony
+++ b/protobuf/_plugin/codegen_enums.pony
@@ -4,26 +4,22 @@ primitive CodeGenEnums
   fun apply(
     writer: CodeGenWriter ref,
     template_ctx: GenTemplate,
-    enums: Array[EnumDescriptorProto] box,
+    enums: Array[ValidEnumDescriptorProto] box,
     prefix: String = "")
   =>
     let field_acc = Array[(String, I32)]
     for enum in enums.values() do
-      try
-        let proto_name = enum.name as String
-        let enum_name = GenNames.top_level_name(proto_name.clone(), prefix)
-        for field in enum.value.values() do
-          let proto_field_name = field.name as String
-          let enum_field_name = GenNames.top_level_name(
-            proto_field_name.clone(),
-            enum_name
-          )
-          field_acc.push((
-            enum_field_name,
-            field.number as I32
-          ))
-        end
-        writer.write_enum(enum_name, field_acc, template_ctx)
+      let enum_name = GenNames.top_level_name(enum.name.clone(), prefix)
+      for (field, number) in enum.values.values() do
+        field_acc.push((
+          GenNames.top_level_name(field.clone(), enum_name),
+          number
+        ))
       end
+      writer.write_enum(
+        enum_name,
+        field_acc,
+        template_ctx
+      )
       field_acc.clear()
     end

--- a/protobuf/_plugin/codegen_messages.pony
+++ b/protobuf/_plugin/codegen_messages.pony
@@ -5,30 +5,35 @@ primitive CodeGenMessages
     writer: CodeGenWriter ref,
     template_ctx: GenTemplate,
     scope_map: SymbolScopeMap,
-    messages: Array[DescriptorProto],
-    prefix: String = "",
-    recursion_level: USize = 0)
+    messages: Array[ValidDescriptorProto] box,
+    prefix: String = "")
+    : (String | None)
   =>
-    if recursion_level > CodeGen.recursion_limit() then
-      // TODO(borja): Inform caller here
-      return
-    end
-
     for message in messages.values() do
-      try
-        let proto_name = message.name as String
-        let message_name = GenNames.top_level_name(proto_name.clone(), prefix)
-
-        CodeGenEnums(writer, template_ctx, message.enum_type, message_name)
-        CodeGenMessages(writer, template_ctx, scope_map, message.nested_type,
-          message_name, recursion_level + 1)
-
-        // We did a scope pass first, this shouldn't fail
-        // Have box capability since we don't want children to
-        // modify the scope.
-        let my_scope = scope_map(message_name) as SymbolScope box
-        let field_meta =
-          CodeGenFields(writer, template_ctx, my_scope, message.field)
-        writer.write_message(message_name, field_meta, template_ctx)
-      end // TODO(borja): What do we do about anonymous messages?
+      let message_name = GenNames.top_level_name(message.name.clone(), prefix)
+      CodeGenEnums(writer, template_ctx, message.nested_enums, message_name)
+      let inner_result = CodeGenMessages(writer, template_ctx, scope_map,
+        message.nested_messages, message_name)
+      match inner_result
+      | let error_reason: String => return error_reason
+      | None =>
+        try
+          // We did a scope pass first, this shouldn't fail
+          // Have box capability since we don't want children to
+          // modify the scope.
+          let my_scope = scope_map(message_name) as SymbolScope box
+          let field_meta_result = CodeGenFields(writer, template_ctx, my_scope,
+            message.fields)
+          match field_meta_result
+          | (Error, let error_reason: String) =>
+          | (Error, let error_reason: String) =>
+            return error_reason
+          | (Ok, let field_meta: Array[FieldMeta] val) =>
+            writer.write_message(message_name, field_meta, template_ctx)
+          end
+        else
+          return "pony-protobuf internal error: can't find symbol scope for " +
+            message_name
+        end
+      end
     end

--- a/protobuf/_plugin/codegen_scope_pass.pony
+++ b/protobuf/_plugin/codegen_scope_pass.pony
@@ -2,84 +2,73 @@ use ".."
 
 primitive CodeGenScopePass
   fun apply(
-    descriptor: FileDescriptorProto,
+    descriptor: ValidFileDescriptorProto,
     scope_map: SymbolScopeMap,
     scope: SymbolScope,
     prefix: String = ""
   ) =>
-    _scope_enums(descriptor.enum_type, scope, prefix)
-    _scope_messages(descriptor.message_type, scope_map, scope, prefix)
+    _scope_enums(descriptor.enums, scope, prefix)
+    _scope_messages(descriptor.messages, scope_map, scope, prefix)
 
   fun _scope_enums(
-    enums: Array[EnumDescriptorProto],
+    enums: Array[ValidEnumDescriptorProto] val,
     scope: SymbolScope,
     prefix: String)
   =>
     for enum in enums.values() do
-      try
-        let proto_name = enum.name as String
-        let enum_name = GenNames.top_level_name(proto_name.clone(), prefix)
-        // This is an artifial scope, we're not interested in finding it
-        // later, but we want the prefixing capabilities when adding to it,
-        // such that the changes are propagated upwards as we append
-        // the prefixes.
-        let local_scope = SymbolScope(proto_name, scope)
-        for field in enum.value.values() do
-          let proto_field_name = field.name as String
-          let enum_field_name = GenNames.top_level_name(
-            proto_field_name.clone(),
-            enum_name
-          )
-          // Enums have weird scoping rules. If we have the following:
-          //
-          // enum Enum {
-          //  FOO = 0;
-          //  BAR = 1;
-          //  BAZ = 2;
-          // }
-          //
-          // Then any sibling type (and its children) of Enum can refer to FOO,
-          // instead of Enum.FOO (although that's also visible)
-          // This means that enums don't have their own scope, but instead
-          // leak their contents outside of the type. To prevent scope
-          // pollution to parents of the enum, we insert the raw field
-          // name locally to this scope only, but we allow the fully-qualified
-          // name to propagate upwards.
-          //
-          // That is, this line will add "FOO" to the local scope, and will be
-          // propagated upwards as "Enum.FOO", and the next one will add
-          // "FOO" to the parent scope, but will not allow us to refer to the
-          // enum field as "Parent.FOO", since that's not correct.
-          local_scope(proto_field_name) = enum_field_name
-          scope.local_insert(proto_field_name, enum_field_name)
-        end
-        // Only let the fully-qualified scope name be visible to outer scopes
-        scope(proto_name) = enum_name
+      let enum_name = GenNames.top_level_name(enum.name.clone(), prefix)
+      // This is an artifial scope, we're not interested in finding it
+      // later, but we want the prefixing capabilities when adding to it,
+      // such that the changes are propagated upwards as we append
+      // the prefixes.
+      let local_scope = SymbolScope(enum.name, scope)
+      for (field_name, field_number) in enum.values.values() do
+        let enum_field_name = GenNames.top_level_name(
+          field_name.clone(),
+          enum_name
+        )
+        // Enums have weird scoping rules. If we have the following:
+        //
+        // enum Enum {
+        //  FOO = 0;
+        //  BAR = 1;
+        //  BAZ = 2;
+        // }
+        //
+        // Then any sibling type (and its children) of Enum can refer to FOO,
+        // instead of Enum.FOO (although that's also visible)
+        // This means that enums don't have their own scope, but instead
+        // leak their contents outside of the type. To prevent scope
+        // pollution to parents of the enum, we insert the raw field
+        // name locally to this scope only, but we allow the fully-qualified
+        // name to propagate upwards.
+        //
+        // That is, this line will add "FOO" to the local scope, and will be
+        // propagated upwards as "Enum.FOO", and the next one will add
+        // "FOO" to the parent scope, but will not allow us to refer to the
+        // enum field as "Parent.FOO", since that's not correct.
+        local_scope(field_name) = enum_field_name
+        scope.local_insert(field_name, enum_field_name)
       end
+      // Only let the fully-qualified scope name be visible to outer scopes
+      scope(enum.name) = enum_name
     end
 
   fun _scope_messages(
-    messages: Array[DescriptorProto],
+    messages: Array[ValidDescriptorProto] val,
     scope_map: SymbolScopeMap,
     outer_scope: SymbolScope,
-    prefix: String,
-    recursion_level: USize = 0)
+    prefix: String)
   =>
-    if recursion_level > CodeGen.recursion_limit() then
-      // TODO(borja): Inform caller here
-      return
-    end
-
     for message in messages.values() do
-      try
-        let proto_name = message.name as String
-        let message_name = GenNames.top_level_name(proto_name.clone(), prefix)
-        outer_scope(proto_name) = message_name
+      let message_name = GenNames.top_level_name(
+        message.name.clone(), prefix
+      )
+      outer_scope(message.name) = message_name
 
-        let local_scope = SymbolScope(proto_name, outer_scope)
-        scope_map(message_name) = local_scope
-        _scope_enums(message.enum_type, local_scope, message_name)
-        _scope_messages(message.nested_type, scope_map, local_scope,
-          message_name, recursion_level + 1)
-      end
+      let local_scope = SymbolScope(message.name, outer_scope)
+      scope_map(message_name) = local_scope
+      _scope_enums(message.nested_enums, local_scope, message_name)
+      _scope_messages(message.nested_messages, scope_map, local_scope,
+        message_name)
     end

--- a/protobuf/_plugin/codegen_writer.pony
+++ b/protobuf/_plugin/codegen_writer.pony
@@ -646,6 +646,7 @@ class CodeGenWriter
       Debug.err("failed to fill template for " + message_name)
     end
 
-  fun ref done(): String val =>
+  // TODO(borja): Track errors, return if anything happened when writing
+  fun ref done(): Result[String, String] =>
     let to_ret = _str = recover String end
-    consume to_ret
+    (Ok, consume to_ret)

--- a/protobuf/_plugin/gen_types.pony
+++ b/protobuf/_plugin/gen_types.pony
@@ -1,76 +1,101 @@
 use ".."
 
+primitive BoolFieldType
+primitive I32FieldType
+primitive U32FieldType
+primitive I64FieldType
+primitive U64FieldType
+primitive I32ZigZagFieldType
+primitive I64ZigZagFieldType
+primitive F32FieldType
+primitive F64FieldType
+primitive FixedI32FieldType
+primitive FixedI64FieldType
+primitive FixedU32FieldType
+primitive FixedU64FieldType
+primitive StringFieldType
+primitive BytesFieldType
+
+// Types that are directly translatable to Pony
+type AllowedProtoTypes is (
+  BoolFieldType
+  | I32FieldType
+  | U32FieldType
+  | I64FieldType
+  | U64FieldType
+  | I32ZigZagFieldType
+  | I64ZigZagFieldType
+  | F32FieldType
+  | F64FieldType
+  | FixedI32FieldType
+  | FixedI64FieldType
+  | FixedU32FieldType
+  | FixedU64FieldType
+  | StringFieldType
+  | BytesFieldType
+)
+
 primitive GenTypes
   fun _proto_type_to_tag_kind(
-    typ: FieldDescriptorProtoType)
+    typ: AllowedProtoTypes)
     : (TagKind, Bool)
   =>
     match typ
-    | FieldDescriptorProtoTypeTYPEDOUBLE => (Fixed64Field, false)
-    | FieldDescriptorProtoTypeTYPEFLOAT => (Fixed32Field, false)
-    | FieldDescriptorProtoTypeTYPEINT64 => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPEUINT64 => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPEINT32 => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPEFIXED32 => (Fixed32Field, false)
-    | FieldDescriptorProtoTypeTYPEFIXED64 => (Fixed64Field, false)
-    | FieldDescriptorProtoTypeTYPEBOOL => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPESTRING => (DelimitedField, false)
-    | FieldDescriptorProtoTypeTYPEMESSAGE => (DelimitedField, false)
-    | FieldDescriptorProtoTypeTYPEBYTES => (DelimitedField, false)
-    | FieldDescriptorProtoTypeTYPEUINT32 => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPEENUM => (VarintField, false)
-    | FieldDescriptorProtoTypeTYPESFIXED32 => (Fixed32Field, false)
-    | FieldDescriptorProtoTypeTYPESFIXED64 => (Fixed64Field, false)
-    | FieldDescriptorProtoTypeTYPESINT32 => (VarintField, true)
-    | FieldDescriptorProtoTypeTYPESINT64 => (VarintField, true)
-    else
-      // Group type?
-      (DelimitedField, false)
+    | BoolFieldType => (VarintField, false)
+    | I32FieldType => (VarintField, false)
+    | U32FieldType => (VarintField, false)
+    | I64FieldType => (VarintField, false)
+    | U64FieldType => (VarintField, false)
+    | I32ZigZagFieldType => (VarintField, true)
+    | I64ZigZagFieldType => (VarintField, true)
+    | F32FieldType => (Fixed32Field, false)
+    | F64FieldType => (Fixed64Field, false)
+    | FixedI32FieldType => (Fixed32Field, false)
+    | FixedI64FieldType => (Fixed64Field, false)
+    | FixedU32FieldType => (Fixed32Field, false)
+    | FixedU64FieldType => (Fixed64Field, false)
+    | StringFieldType => (DelimitedField, false)
+    | BytesFieldType => (DelimitedField, false)
     end
 
   fun _proto_type_to_pony_type(
-    typ: FieldDescriptorProtoType,
+    typ: AllowedProtoTypes,
     label: FieldDescriptorProtoLabel)
-    : ((String, String) | None)
+    : (String, String)
   =>
     match typ
-    | FieldDescriptorProtoTypeTYPEDOUBLE => label_of("F64", label)
-    | FieldDescriptorProtoTypeTYPEFLOAT => label_of("F32", label)
-    | FieldDescriptorProtoTypeTYPEINT64 => label_of("I64", label)
-    | FieldDescriptorProtoTypeTYPEUINT64 => label_of("U64", label)
-    | FieldDescriptorProtoTypeTYPEINT32 => label_of("I32", label)
-    | FieldDescriptorProtoTypeTYPEFIXED32 => label_of("U32", label)
-    | FieldDescriptorProtoTypeTYPEFIXED64 => label_of("U64", label)
-    | FieldDescriptorProtoTypeTYPEBOOL => label_of("Bool", label)
-    | FieldDescriptorProtoTypeTYPESTRING => label_of("String", label)
-    | FieldDescriptorProtoTypeTYPEMESSAGE => None // Caller needs to check scope
-    | FieldDescriptorProtoTypeTYPEBYTES => label_of("Array[U8]", label)
-    | FieldDescriptorProtoTypeTYPEUINT32 => label_of("U32", label)
-    | FieldDescriptorProtoTypeTYPEENUM => None // Caller needs to check scope
-    | FieldDescriptorProtoTypeTYPESFIXED32 => label_of("I32", label)
-    | FieldDescriptorProtoTypeTYPESFIXED64 => label_of("I64", label)
-    | FieldDescriptorProtoTypeTYPESINT32 => label_of("I32", label)
-    | FieldDescriptorProtoTypeTYPESINT64 => label_of("I64", label)
-    else
-      // Group type?
-      None
+    | BoolFieldType => label_of("Bool", label)
+    | I32FieldType => label_of("I32", label)
+    | U32FieldType => label_of("U32", label)
+    | I64FieldType => label_of("I64", label)
+    | U64FieldType => label_of("U64", label)
+    | I32ZigZagFieldType => label_of("I32", label)
+    | I64ZigZagFieldType => label_of("I64", label)
+    | F32FieldType => label_of("F32", label)
+    | F64FieldType => label_of("F64", label)
+    | FixedI32FieldType => label_of("I32", label)
+    | FixedI64FieldType => label_of("I64", label)
+    | FixedU32FieldType => label_of("U32", label)
+    | FixedU64FieldType => label_of("U64", label)
+    | StringFieldType => label_of("String", label)
+    | BytesFieldType => label_of("Array[U8]", label)
     end
 
   fun _default_for_type_label(
     pony_type_decl: String,
     default: (String | None),
-    typ_info: FieldDescriptorProtoType,
+    typ_info: AllowedProtoTypes,
     label: FieldDescriptorProtoLabel)
     : String
   =>
     match default
-    | String if typ_info is FieldDescriptorProtoTypeTYPEBYTES =>
+    | String if typ_info is BytesFieldType =>
         // Proto default is a string that represents C-escaped values
         // TODO(borja): Figure how to de-escape default bytes
         // Check https://github.com/golang/protobuf/pull/427
         "Array[U8]"
 
-    | let str: String if typ_info is FieldDescriptorProtoTypeTYPESTRING =>
+    | let str: String if typ_info is StringFieldType =>
         // Quote default
         "\"" + str + "\""
 
@@ -82,35 +107,34 @@ primitive GenTypes
     end
 
   fun typeof(
-    typ: FieldDescriptorProtoType,
+    typ: AllowedProtoTypes,
     label: FieldDescriptorProtoLabel,
     typ_default_value: (String | None))
-    : ((TagKind, Bool) | (TagKind, Bool, String, String, String))
+    : (TagKind, Bool, String, String, String)
   =>
     """
-    Returns the tag kind if the type needs zigzag encoding. Optionally, it also
-    returns the type of the field, and the type of indicated in the proto file.
+    Returns the wire type, if the type needs zigzag encoding, the translated
+    Pony type used for the variable definition, the inner type (if the Pony
+    type is an array, the type of the elements), and the default value to
+    assign to the field.
+
     That is, for optional fields,  the type is "( Type | None )", and the
     other type is "Type". For repeated types, the types are "Array[Type]" and
     "Type", respectively.
-
-    If only the tag is returned, caller needs to check SymbolScope.
     """
 
     (let tag_kind, let uses_zigzag) = _proto_type_to_tag_kind(typ)
-    match _proto_type_to_pony_type(typ, label)
-    | None => (tag_kind, uses_zigzag)
-    | (let pony_type: String, let pony_inner_type: String) =>
-      (
-        tag_kind,
-        uses_zigzag,
-        pony_type,
-        pony_inner_type,
-        _default_for_type_label(
-          pony_type, typ_default_value, typ, label
-        )
+    (let pony_type: String, let pony_inner_type) =
+      _proto_type_to_pony_type(typ, label)
+    (
+      tag_kind,
+      uses_zigzag,
+      pony_type,
+      pony_inner_type,
+      _default_for_type_label(
+        pony_type, typ_default_value, typ, label
       )
-    end
+    )
 
   fun varint_kind(
     is_zigzag: Bool,

--- a/protobuf/_plugin/result.pony
+++ b/protobuf/_plugin/result.pony
@@ -1,0 +1,71 @@
+primitive Ok
+primitive Error
+type Result[L, R] is ((Ok, L) | (Error, R))
+
+primitive Results[L, R]
+  fun ok(l: L): Result[L, R] => (Ok, consume l)
+  fun to_error(r: R): Result[L, R] => (Error, consume r)
+  
+  fun force_ok(e: Result[L, R]): L^ ? =>
+    match e
+    | (Ok, let l: L) => consume l
+    else
+      error
+    end
+    
+  fun force_error(res: Result[L, R]): R^ ? =>
+    match res
+    | (Error, let r: R) => consume r
+    else
+      error
+    end
+
+  fun lmap[T = L](
+    res: Result[L, R],
+    op: {(L): T^})
+    : Result[T^, R]
+  =>
+    match res
+    | (Ok, let l: L) => (Ok, op.apply(consume l))
+    | (Error, let r: R) => (Error, consume r)
+    end
+
+  fun rmap[T = R](
+    res: Result[L, R],
+    op: {(R): T^})
+    : Result[L, T^]
+  =>
+    match res
+    | (Ok, let l: L) => (Ok, consume l)
+    | (Error, let r: R) => (Error, op.apply(consume r))
+    end
+
+  fun flat_lmap[T = L](
+    res: Result[L, R],
+    op: {(L):  Result[T^, R]})
+    : Result[T^, R]
+  =>
+    match res
+    | (Error, let r: R) => (Error, r)
+    | (Ok, let l: L) => op.apply(consume l)
+    end
+
+  fun flat_rmap[T = R](
+    res: Result[L, R],
+    op: {(R):  Result[L, T^]})
+    : Result[L, T^]
+  =>
+    match res
+    | (Ok, let l: L) => (Ok, l)
+    | (Error, let r: R) => op.apply(consume r)
+    end
+
+  fun apply(
+    res: Result[L, R],
+    op_ok: {(L)},
+    op_error: {(R)} = {(_) => None})
+  =>
+    match res
+    | (Ok, let l: L) => op_ok(consume l)
+    | (Error, let r: R) => op_error(consume r)
+    end

--- a/protobuf/_plugin/scope.pony
+++ b/protobuf/_plugin/scope.pony
@@ -28,29 +28,22 @@ class SymbolScope
     _parent = parent'
     _level_prefix = scope_prefix'
 
-  fun apply(name: String): (String | None) =>
-    // Debug.err("scope query for " + name )
+  fun apply(name: String): String ? =>
     try
-      let res = _definitions(name)?
-      // Debug.err("resulting in " + res)
-      res
+      _definitions(name)?
     else
-      // If parent is None this will return None
-      try (_parent as this->SymbolScope)(name) end
+      (_parent as this->SymbolScope)(name)?
     end
 
   fun ref update(name: String, value: String) =>
-    // Debug.err("scope insert " + name + ": " + value)
     _definitions(name) = value
     let parent_scoped: String = _level_prefix + "." + name
     match _parent
     | let parent: SymbolScope => parent(parent_scoped) = value
     | None =>
       // We're the top scope, add with level prefix
-      // Debug.err("scope insert " + parent_scoped + ": " + value)
       _definitions(parent_scoped) = value
     end
 
   fun ref local_insert(name: String, value: String) =>
-    // Debug.err("local scope insert " + name + ": " + value)
     _definitions(name) = value

--- a/protobuf/_plugin/valid_types.pony
+++ b/protobuf/_plugin/valid_types.pony
@@ -1,0 +1,80 @@
+use ".."
+
+class val ValidEnumDescriptorProto
+  let name: String
+  let values: Array[(String, I32)] val
+
+  new val create(
+    name': String,
+    values': Array[(String, I32)] val)
+  =>
+    name = name'
+    values = values'
+
+class val ValidFieldDescriptorProto
+  let name: String
+  let number: I32
+  let label: FieldDescriptorProtoLabel
+  // Either an explicit proto type, or the name of the type
+  // (will be either message, or enum, since groups are removed)
+  let type_field: (AllowedProtoTypes | None)
+  let type_name: ((MessageType, String) | (EnumType, String) | None)
+  let default_value: (String | None)
+  let oneof_index: (I32 | None)
+  let is_packed: Bool
+
+  new val create(
+    name': String,
+    number': I32,
+    label': FieldDescriptorProtoLabel,
+    type_field': (AllowedProtoTypes | None),
+    type_name': ((MessageType, String) | (EnumType, String) | None),
+    default_value': (String | None),
+    oneof_index': (I32 | None),
+    is_packed': Bool)
+  =>
+    name = name'
+    number = number'
+    label = label'
+    type_field = type_field'
+    type_name = type_name'
+    default_value = default_value'
+    oneof_index = oneof_index'
+    is_packed = is_packed'
+
+class val ValidDescriptorProto
+  let name: String
+  let fields: Array[ValidFieldDescriptorProto] val
+  let nested_enums: Array[ValidEnumDescriptorProto] val
+  let nested_messages: Array[ValidDescriptorProto] val
+  let oneof_decls: Array[String] val
+
+  new val create(
+    name': String,
+    fields': Array[ValidFieldDescriptorProto] val,
+    nested_enums': Array[ValidEnumDescriptorProto] val,
+    nested_messages': Array[ValidDescriptorProto] val,
+    oneof_decls': Array[String] val)
+  =>
+    name = name'
+    fields = fields'
+    nested_enums = nested_enums'
+    nested_messages = nested_messages'
+    oneof_decls = oneof_decls'
+
+class val ValidFileDescriptorProto
+  let name: String
+  let package: String
+  let enums: Array[ValidEnumDescriptorProto] val
+  let messages: Array[ValidDescriptorProto] val
+
+  new val create(
+    name': String,
+    package': String,
+    enums': Array[ValidEnumDescriptorProto] val,
+    messages': Array[ValidDescriptorProto] val)
+  =>
+    name = name'
+    package = package'
+    enums = enums'
+    messages = messages'


### PR DESCRIPTION
Add a pre-scope pass, the check pass, that converts all types to valid ones, and reports any error it encounters.